### PR TITLE
fix: put Quantity and Seller Name in two span

### DIFF
--- a/src/components/custom/Product/PurchaseItem.tsx
+++ b/src/components/custom/Product/PurchaseItem.tsx
@@ -102,9 +102,9 @@ export const PurchaseItem = ({
           <HiOutlineCheckBadge className="w-5 h-5 mr-4 text-green-700" />
         )}
 
-        <span className="font-bold w-1/6">
-          {purchase.quantity} x {purchase.seller.name}
-        </span>
+        <span className="font-bold pr-5">{purchase.quantity} x</span>
+
+        <span className="font-bold w-1/6">{purchase.seller.name}</span>
         <span className="w-1/6">
           {selectTranslation(
             purchase.product.name_en,


### PR DESCRIPTION
to prevent multilines Seller Names from including the quantity

**Before:**
<img width="899" alt="Capture d’écran 2024-08-20 à 12 04 24" src="https://github.com/user-attachments/assets/f8189c7a-cd4b-42df-af92-20cdf96a8a73">
**After:**
<img width="897" alt="Capture d’écran 2024-08-20 à 12 05 41" src="https://github.com/user-attachments/assets/c1939d96-7da4-46c8-8a3f-77e2241b639a">
