### PR TITLE
fix: set open accordion items only when there are products available

### DIFF
--- a/src/components/admin/adminPanel/AdminPanel.tsx
+++ b/src/components/admin/adminPanel/AdminPanel.tsx
@@ -12,7 +12,7 @@ interface AdminPanelProps {
 
 export const AdminPanel = ({ sellers, status }: AdminPanelProps) => {
   return (
-    <Accordion type="multiple">
+    <Accordion type="multiple" defaultValue={["status"]}>
       <SellerAccordionItem sellers={sellers} />
       <CurriculumAccordionItem />
       <StatusAccordionItem status={status} />

--- a/src/components/admin/sellerProducts/SellerTabContent.tsx
+++ b/src/components/admin/sellerProducts/SellerTabContent.tsx
@@ -37,7 +37,8 @@ export const SellerTabContent = ({
       typeof window !== "undefined" &&
       productExpansion[seller.id] === undefined &&
       seller.id === activeSellerId &&
-      products
+      products &&
+      products.length > 0
     ) {
       setExpandedProducts(
         seller.id,

--- a/src/components/user/ProductPanel.tsx
+++ b/src/components/user/ProductPanel.tsx
@@ -38,7 +38,8 @@ export const ProductPanel = () => {
       typeof window !== "undefined" &&
       productExpansion[firstSellerId] === undefined &&
       seller?.id === firstSellerId &&
-      onlineProducts
+      onlineProducts &&
+      onlineProducts.length > 0
     ) {
       setExpandedProducts(
         firstSellerId,


### PR DESCRIPTION
to prevent them from being set before products are loaded